### PR TITLE
chore(ci): extract Yarn setup to composite action and align Docker Yarn files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ dist
 build
 coverage
 .angular
+.yarn/install-state.gz
 .sass-cache
 .vscode
 .idea

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -1,0 +1,17 @@
+name: Setup Node, Corepack, and Yarn dependencies
+description: Configure Node.js, enable Corepack, and install dependencies with Yarn immutable mode
+runs:
+  using: composite
+  steps:
+    - name: Use Node.js 25.9.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 25.9.0
+
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --immutable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,16 +26,8 @@ jobs:
       - name: Make checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Use Node.js 25.9.0
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 25.9.0
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Setup Node + Corepack + Yarn deps
+        uses: ./.github/actions/setup-yarn
 
       - name: Run `yarn lint:ts`
         run: yarn lint:ts
@@ -48,16 +40,8 @@ jobs:
       - name: Make checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Use Node.js 25.9.0
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 25.9.0
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Setup Node + Corepack + Yarn deps
+        uses: ./.github/actions/setup-yarn
 
       - name: Run `yarn lint:scss`
         run: yarn lint:scss
@@ -85,16 +69,8 @@ jobs:
       - name: Make checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Use Node.js 25.9.0
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 25.9.0
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Setup Node + Corepack + Yarn deps
+        uses: ./.github/actions/setup-yarn
 
       - name: Run `yarn run extract-translations && git diff --exit-code`
         run: yarn run extract-translations && git diff --exit-code
@@ -107,16 +83,8 @@ jobs:
       - name: Make checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Use Node.js 25.9.0
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 25.9.0
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Setup Node + Corepack + Yarn deps
+        uses: ./.github/actions/setup-yarn
 
       - name: Run `yarn run check-translations`
         run: yarn run check-translations

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:25.9.0-bullseye AS dependencies
 WORKDIR /app
 
 COPY package.json yarn.lock .yarnrc.yml version.js ./
-COPY .yarn/releases ./.yarn/releases
+COPY .yarn ./.yarn
 
 RUN yarn install --immutable
 


### PR DESCRIPTION
## Summary
Refactors Yarn/Node setup used in CI into a reusable composite action and updates Docker dependency install inputs to include the full `.yarn` directory.

## Changes
- Added `.github/actions/setup-yarn/action.yml` to centralize:
  - Node 25.9.0 setup
  - Corepack enablement
  - `yarn install --immutable`
- Updated `.github/workflows/main.yml` jobs to use the new composite action instead of duplicated setup steps
- Updated `Dockerfile` to copy `.yarn` (not only `.yarn/releases`) before dependency install
- Updated `.dockerignore` to include `.yarn/install-state.gz`

## Why
- Reduces duplicated CI workflow steps
- Keeps Yarn setup consistent across jobs
- Ensures Docker builds have all required Yarn metadata/files